### PR TITLE
Updated dependencies on barback and html5lib

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,5 +9,5 @@ authors:
 version: 3.3.0+1
 homepage: https://github.com/sethladd/bootstrap_for_pub
 dependencies:
-  barback: ">=0.14.1+3 <0.15.0"
-  html5lib: ">=0.11.0+1 <0.12.0"
+  barback: ">=0.14.1+3 <0.16.0"
+  html5lib: ">=0.11.0+1 <0.13.0"


### PR DESCRIPTION
I could not test if this still works.
Polymer.dart requires a newer version of barback, but I immediatelly updated both.

Please verify first of this works, but I doubt that it would be a problem, considering the changelog of both libraries.
