### PR TITLE
Upgraded deprecated html5lib package to html package

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -5,8 +5,8 @@
 
 library bootstrap;
 
-import 'package:html5lib/parser.dart' show parse;
-import 'package:html5lib/dom.dart' show Document;
+import 'package:html/parser.dart' show parse;
+import 'package:html/dom.dart' show Document;
 import 'package:barback/barback.dart'
   show Asset, Transform, Transformer, BarbackSettings, BarbackMode;
 import 'dart:async' show Future;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,4 @@ version: 4.0.0-alpha.6
 homepage: https://github.com/richerlariviere/bootstrap_for_pub
 dependencies:
   barback: ">=0.14.1+3 <0.16.0"
-  html5lib: ">=0.11.0+1 <0.13.0"
+  html: ">=0.12.0 <0.14.0"


### PR DESCRIPTION
html5lib package has been renamed to html.

Old name makes dependency incompatibilities with other packages like angular